### PR TITLE
Add event for team member or attribute changes

### DIFF
--- a/src/main/java/cn/leomc/teamprojecte/TeamChangeEvent.java
+++ b/src/main/java/cn/leomc/teamprojecte/TeamChangeEvent.java
@@ -1,0 +1,58 @@
+package cn.leomc.teamprojecte;
+
+import net.minecraftforge.eventbus.api.Event;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+/**
+ * Fired on the server when either:
+ * <ul>
+ *     <li>A player leaves or joins a team</li>
+ *     <li>A team has changed its owner or whether it is sharing EMC or knowledge</li>
+ * </ul>
+ * In the latter case, the values for a player UUID and new team will be {@code null}.
+ * <p>
+ * This event is fired on {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS}. It is not
+ * {@link net.minecraftforge.eventbus.api.Cancelable}, and has no result.
+ */
+public class TeamChangeEvent extends Event {
+    @Nullable
+    private final UUID playerUUID;
+    @Nullable
+    private final TPTeam team;
+    @Nullable
+    private final TPTeam newTeam;
+
+    public TeamChangeEvent(@Nullable UUID playerUUID, @Nullable TPTeam team, @Nullable TPTeam newTeam) {
+        this.playerUUID = playerUUID;
+        this.team = team;
+        this.newTeam = newTeam;
+    }
+
+    /**
+     * @return The UUID of the player changing teams, or {@code null} if no team member changes have occurred.
+     */
+    @Nullable
+    public UUID getPlayerUUID() {
+        return playerUUID;
+    }
+
+    /**
+     * @return The team being changed, either in members, owner or sharing status, or {@code null} if a player joins
+     * a team but was not already in another team.
+     */
+    @Nullable
+    public TPTeam getTeam() {
+        return team;
+    }
+
+    /**
+     * @return The new team that a player has joined, or {@code null} if either no team member changes have occurred
+     * or a player has left or been kicked from their old team.
+     */
+    @Nullable
+    public TPTeam getNewTeam() {
+        return newTeam;
+    }
+}


### PR DESCRIPTION
In order for other add-on mods to be able to provide more robust integration with Team ProjectE, this PR introduces a `TeamChangeEvent` for when a player either joins or leaves a team, or when a team changes ownership or whether it is sharing EMC or knowledge.

The rationale for this PR comes from the existing integration with TPE in the [AppliedE](https://github.com/62832/AppliedE) mod, which is designed to keep track of different players' knowledge providers and performs extra filtering depending on whether those players are in the same team which may or may not be sharing EMC. In order to better account for team changes which may require changes to what teams and providers to track, an event would be ideal to use.